### PR TITLE
Fixed code language pt-BR

### DIFF
--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -24,7 +24,7 @@ i18next.use(I18nextBrowserLanguageDetector).init({
         'Postal Code': '郵便番号',
       },
     },
-    pt-BR: {
+    'pt-BR': {
       translation: {
         'Pay': 'Pagar',
         'Failed to load Stripe': 'Falha ao ler Stripe',

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -24,7 +24,7 @@ i18next.use(I18nextBrowserLanguageDetector).init({
         'Postal Code': '郵便番号',
       },
     },
-    br: {
+    pt-BR: {
       translation: {
         'Pay': 'Pagar',
         'Failed to load Stripe': 'Falha ao ler Stripe',
@@ -39,7 +39,7 @@ i18next.use(I18nextBrowserLanguageDetector).init({
         'Country or region': 'País ou região',
         'Postal Code': 'Cep',
       },      
-    }
+    },
   },
 });
 

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -24,6 +24,22 @@ i18next.use(I18nextBrowserLanguageDetector).init({
         'Postal Code': '郵便番号',
       },
     },
+    br: {
+      translation: {
+        'Pay': 'Pagar',
+        'Failed to load Stripe': 'Falha ao ler Stripe',
+        'Add your payment information': 'Informações do seu Pagamento',
+        'Add card': 'Adicionar Cartão',
+        'Add a card': 'Adicionar um Cartão',
+        'Add': 'Adicionar',
+        'Card information': 'Informações do Cartão',
+        'Card Number': 'Número do Cartão',
+        'MM / YY': 'MM / AA',
+        'CVC': 'Número de Segurança(CVC)',
+        'Country or region': 'País ou região',
+        'Postal Code': 'Cep',
+      },      
+    }
   },
 });
 


### PR DESCRIPTION
Follow the pull request, with the correction of the Brazilian Portuguese language code according to the i18next documentation. Corrected to "pt-BR" as per documentation.

My apologies for the previous pull request.